### PR TITLE
[0.3.2] pull request for issue #5: implement verbose and non-verbose printing

### DIFF
--- a/include/path_tree.h
+++ b/include/path_tree.h
@@ -7,6 +7,8 @@
 
 #define ROOT_NAME "[ROOT]"
 #define THROWAWAY_MEMORY_SIZE_FOR_PRINT 3 * KB
+#define PRINT_VERBOSE TRUE
+#define PRINT_NONVERBOSE FALSE
 
 struct PathTree
 {
@@ -18,6 +20,15 @@ struct PathTree
 extern struct PathTree* path_tree_create(Memory* memory);
 extern int path_tree_is_empty(struct PathTree* tree);
 extern int path_tree_insert(Memory* memory, struct PathTree* tree, char* path, char* value);
-extern void path_tree_print(struct PathTree* tree);
+
+extern void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity);
+static inline void path_tree_print(struct PathTree* tree)
+{
+   path_tree_print_choose_verbosity(tree, PRINT_NONVERBOSE);
+}
+static inline void path_tree_print_verbose(struct PathTree* tree)
+{
+   path_tree_print_choose_verbosity(tree, PRINT_VERBOSE);
+}
 
 #endif

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -956,7 +956,7 @@ int main/*_inserts_into_path_tree_and_prints_it*/()
 
    printf("\n[STATUS] Printing an empty newly created tree...\n");
    struct PathTree* tree = path_tree_create(&mem);
-   path_tree_print(tree);
+   path_tree_print_verbose(tree);
    printf("\n");
 
    printf("\n[STATUS] Inserting to path [c] and printing out...\n");

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -957,7 +957,6 @@ int main/*_inserts_into_path_tree_and_prints_it*/()
    printf("\n[STATUS] Printing an empty newly created tree...\n");
    struct PathTree* tree = path_tree_create(&mem);
    path_tree_print_verbose(tree);
-   printf("\n");
 
    printf("\n[STATUS] Inserting to path [c] and printing out...\n");
    path_tree_insert(&mem, tree, "c", "ccc");

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -1026,6 +1026,10 @@ int main/*_inserts_into_path_tree_and_prints_it*/()
    path_tree_print(tree);
    printf("\n");
 
+   printf("\n[STATUS] Now trying to print verbosely and see what changes...\n");
+   path_tree_print_verbose(tree);
+   printf("\n");
+
    memory_usage_status(&mem);
    printf("main_inserts_into_path_tree_and_prints_it: OK\n");
    free(mem.pointer);
@@ -1172,4 +1176,33 @@ int main_tests_trying_to_insert_into_incorrect_paths()
    memory_usage_status(&mem);
    printf("main_tests_corner_cases_of_tree_insertion_and_printing: OK\n\n");
    return 0;
+}
+
+int main_small_print_verbose_test()
+{
+   printf("main_small_print_verbose_test:\n");
+   Memory mem = memory_create(1 * KB);
+
+   printf("\n[STATUS] Creating a tree and inserting 3 small nodes:\n");
+   printf("[a/smol/lil/node], [a/big/lil/node], [a/smol/cool/pp], [a/big/lil/ahaha kek]...\n");
+   struct PathTree* tree = path_tree_create(&mem);
+   path_tree_insert(&mem, tree, "a/smol/lil/node", "ln");
+   path_tree_insert(&mem, tree, "a/big/lil/node", "bn");
+   path_tree_insert(&mem, tree, "a/smol/cool/pp", "pp");
+   path_tree_insert(&mem, tree, "a/big/lil/ahaha kek", "ak");
+
+   printf("\n[STATUS] Now printing it verbosely...\n");
+   path_tree_print_verbose(tree);
+
+   printf("\n[STATUS] Now changing [a/big/lil/ahaha kek]'s value to [KEKW]...\n");
+   path_tree_insert(&mem, tree, "a/big/lil/ahaha kek", "KEKW");
+
+   printf("\n[STATUS] Now printing it non-verbosely...\n");
+   path_tree_print(tree);
+
+   memory_usage_status(&mem);
+   printf("\nmain_small_print_verbose_test: OK\n");
+   free(mem.pointer);
+   return 0;
+
 }

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -1183,7 +1183,7 @@ int main_small_print_verbose_test()
    printf("main_small_print_verbose_test:\n");
    Memory mem = memory_create(1 * KB);
 
-   printf("\n[STATUS] Creating a tree and inserting 3 small nodes:\n");
+   printf("\n[STATUS] Creating a tree and inserting 4 small nodes:\n");
    printf("[a/smol/lil/node], [a/big/lil/node], [a/smol/cool/pp], [a/big/lil/ahaha kek]...\n");
    struct PathTree* tree = path_tree_create(&mem);
    path_tree_insert(&mem, tree, "a/smol/lil/node", "ln");
@@ -1205,4 +1205,37 @@ int main_small_print_verbose_test()
    free(mem.pointer);
    return 0;
 
+}
+
+int main_checks_nonverbose_printing_of_empty_trees()
+{
+   printf("main_checks_nonverbose_printing_of_empty_trees:\n");
+   Memory mem = memory_create(1 * KB);
+
+   printf("\n[STATUS] Creating an empty tree and printing\n");
+   printf("         with both verbose and non-verbose prints...\n");
+   struct PathTree* tree = path_tree_create(&mem);
+   printf("[STATUS] Now printing with a non-verbose print...\n");
+   path_tree_print(tree);
+   printf("[STATUS] Now printing with a verbose print...\n");
+   path_tree_print_verbose(tree);
+
+   printf("\n[STATUS] inserting 4 small nodes:\n");
+   printf("[a/smol/lil/node], [a/big/lil/node], [a/smol/cool/pp], [a/big/lil/ahaha kek]...\n");
+   printf("[STATUS] All those nodes have a NULL value...\n");
+   path_tree_insert(&mem, tree, "a/smol/lil/node", NULL);
+   path_tree_insert(&mem, tree, "a/big/lil/node", NULL);
+   path_tree_insert(&mem, tree, "a/smol/cool/pp", NULL);
+   path_tree_insert(&mem, tree, "a/big/lil/ahaha kek", NULL);
+
+   printf("\n[STATUS] Now printing it verbosely...\n");
+   path_tree_print_verbose(tree);
+
+   printf("\n[STATUS] Now printing it non-verbosely...\n");
+   path_tree_print(tree);
+
+   memory_usage_status(&mem);
+   printf("\nmain_checks_nonverbose_printing_of_empty_trees: OK\n");
+   free(mem.pointer);
+   return 0;
 }

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -289,12 +289,10 @@ void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity)
 {
    assert(tree);
 
+   if(verbosity == PRINT_VERBOSE)
+      printf("%s: [EMPTY] [%p]\n", tree->node_name, tree);
    if(path_tree_is_empty(tree))
-   {
-      if(verbosity == PRINT_VERBOSE)
-         printf("%s: [EMPTY] [%p]\n", tree->node_name, tree);
       return;
-   }
 
    Memory throwaway_memory = memory_create(THROWAWAY_MEMORY_SIZE_FOR_PRINT);
    struct PrintTreeInternal throwaway_buffers = {

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -292,7 +292,7 @@ void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity)
    if(path_tree_is_empty(tree))
    {
       if(verbosity == PRINT_VERBOSE)
-         printf("%s: [EMPTY]\n", tree->node_name);
+         printf("%s: [EMPTY] [%p]\n", tree->node_name, tree);
       return;
    }
 

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -229,6 +229,7 @@ struct PrintTreeInternal
 {
    Memory* throwaway_memory;
    char* current_path_prefix;
+   int verbosity_level;
 };
 
 static void path_tree_print_internal(struct PathTree* tree, struct PrintTreeInternal* buffers);
@@ -248,12 +249,18 @@ static void path_tree_print_element(struct List* element, void* data)
    util_build_path_prefix_noalloc(&buffers->current_path_prefix, 
                                   tree_element->node_name);
    if(tree_element->node_value)
-      printf("%s: %s\n"/* [%p]*/, 
-             buffers->current_path_prefix, 
-             tree_element->node_value/*,
-             tree_element*/);
+      if(buffers->verbosity_level == PRINT_VERBOSE)
+         printf("%s: %s [%p]\n", 
+                buffers->current_path_prefix, 
+                tree_element->node_value,
+                tree_element);
+      else
+         printf("%s: %s\n", 
+                buffers->current_path_prefix, 
+                tree_element->node_value);
    else
-      printf("%s: [EMPTY]\n"/* [%p]*/, buffers->current_path_prefix/*, tree_element*/);
+      if(buffers->verbosity_level == PRINT_VERBOSE)
+         printf("%s: [EMPTY] [%p]\n", buffers->current_path_prefix, tree_element);
 
    if(tree_element->children)
       path_tree_print_internal(tree_element, buffers);
@@ -278,7 +285,7 @@ static void path_tree_print_internal(struct PathTree* tree, struct PrintTreeInte
       list_for_each(tree->children, path_tree_print_element, buffers);
 }
 
-void path_tree_print(struct PathTree* tree)
+void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity)
 {
    assert(tree);
 
@@ -291,7 +298,8 @@ void path_tree_print(struct PathTree* tree)
    Memory throwaway_memory = memory_create(THROWAWAY_MEMORY_SIZE_FOR_PRINT);
    struct PrintTreeInternal throwaway_buffers = {
       .throwaway_memory = &throwaway_memory,
-      .current_path_prefix = NULL
+      .current_path_prefix = NULL,
+      .verbosity_level = verbosity
    };
    path_tree_print_internal(tree, &throwaway_buffers);
 

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -291,7 +291,8 @@ void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity)
 
    if(path_tree_is_empty(tree))
    {
-      printf("%s: [EMPTY]\n", tree->node_name);
+      if(verbosity == PRINT_VERBOSE)
+         printf("%s: [EMPTY]\n", tree->node_name);
       return;
    }
 


### PR DESCRIPTION
This pull request implements verbosity in printing trees.
- path_tree_print() is now non-verbose and only prints out non-empty nodes and their values;
- path_tree_print_verbose() is the verbose version of print that also prints out all the empty nodes and pointers to those nodes, which can be useful when debugging path trees;
- When printing out empty path trees or those that only contain empty nodes, path_tree_print()'s behavior is to print nothing while path_tree_print_verbose()'s behavior is to print everything.