### PR TITLE
[0.4.0] pull request for issue #4: finding and printing nodes by path

### DIFF
--- a/include/path_tree.h
+++ b/include/path_tree.h
@@ -32,5 +32,6 @@ static inline void path_tree_print_verbose(struct PathTree* tree)
 }
 
 extern struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char* path);
+extern void path_tree_find_and_print_node(struct PathTree* node, char* path);
 
 #endif

--- a/include/path_tree.h
+++ b/include/path_tree.h
@@ -31,4 +31,6 @@ static inline void path_tree_print_verbose(struct PathTree* tree)
    path_tree_print_choose_verbosity(tree, PRINT_VERBOSE);
 }
 
+extern struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char* path);
+
 #endif

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -946,7 +946,7 @@ int main_investigate_double_alloc_bug()
    return 0;
 }
 
-int main/*_inserts_into_path_tree_and_prints_it*/()
+int main_inserts_into_path_tree_and_prints_it()
 {
    // a gdb print command to see the second element of the tree:
    // print *(struct PathTree*)((*(struct List*)(*(struct PathTree*)tree->children->value)->children)->value)
@@ -1235,6 +1235,60 @@ int main_checks_nonverbose_printing_of_empty_trees()
 
    memory_usage_status(&mem);
    printf("\nmain_checks_nonverbose_printing_of_empty_trees: OK\n");
+   free(mem.pointer);
+   return 0;
+}
+
+void prints_out_find_status(struct PathTree* tree, char* path)
+{
+   assert(tree);
+   assert(path);
+
+   struct PathTree* found = path_tree_find_node_by_path(tree, path);
+   if(!found)
+      printf("[FIND STATE] Node not found!\n");
+   else
+      printf("[FIND STATE] Found node:\n");
+      printf("             %s: [%s]\n", found->node_name, found->node_value);
+}
+
+int main/*_finds_nodes_by_path*/()
+{
+   printf("\nmain_finds_nodes_by_path:\n");
+   Memory mem = memory_create(2 * KB);
+
+   printf("\n[STATUS] Creating a tree with 5 nodes...\n");
+   struct PathTree* tree = path_tree_create(&mem);
+   path_tree_insert(&mem, tree, "m", "W");
+   path_tree_insert(&mem, tree, "me", "hello!");
+   path_tree_insert(&mem, tree, "me/am/bad", "sry :(");
+   path_tree_insert(&mem, tree, "the/actual/what/am/I/doing/right/now", "*shrugs*");
+   path_tree_insert(&mem, tree, "the/actual/gibberish/is/going/on/right/now", "no clue ^_^");
+   path_tree_insert(&mem, tree, "the/actual/gibberish/mwahaha/very/funny/yes", "I know Kappa");
+
+   path_tree_print(tree);
+
+   printf("\n[STATUS] Trying to find [m]...\n");
+   prints_out_find_status(tree, "m");
+
+   printf("\n[STATUS] Trying to find [me]...\n");
+   prints_out_find_status(tree, "me");
+
+   printf("\n[STATUS] Trying to find [me/am/bad]...\n");
+   prints_out_find_status(tree, "me/am/bad");
+
+   printf("\n[STATUS] Trying to find [me/am]...\n");
+   prints_out_find_status(tree, "me/am");
+
+   printf("\n[STATUS] Trying to find [the/actual/gibberish/mwahaha/very/funny/yes]...\n");
+   prints_out_find_status(tree, "the/actual/gibberish/mwahaha/very/funny/yes");
+
+   printf("\n[STATUS] Trying to find [the/actual/what/am/I/doing/right/now]...\n");
+   prints_out_find_status(tree, "the/actual/what/am/I/doing/right/now");
+
+   printf("\n[STATUS] App memory state: ");
+   memory_usage_status(&mem);
+   printf("\nmain_finds_nodes_by_path: OK\n");
    free(mem.pointer);
    return 0;
 }

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -1264,7 +1264,7 @@ int main/*_finds_nodes_by_path*/()
    printf("\nmain_finds_nodes_by_path:\n");
    Memory mem = memory_create(2 * KB);
 
-   printf("\n[STATUS] Creating a tree with 5 nodes...\n");
+   printf("\n[STATUS] Creating a tree with 8 nodes...\n");
    struct PathTree* tree = path_tree_create(&mem);
    path_tree_insert(&mem, tree, "m", "W");
    path_tree_insert(&mem, tree, "me", "hello!");
@@ -1272,6 +1272,8 @@ int main/*_finds_nodes_by_path*/()
    path_tree_insert(&mem, tree, "the/actual/what/am/I/doing/right/now", "*shrugs*");
    path_tree_insert(&mem, tree, "the/actual/gibberish/is/going/on/right/now", "no clue ^_^");
    path_tree_insert(&mem, tree, "the/actual/gibberish/mwahaha/very/funny/yes", "I know Kappa");
+   path_tree_insert(&mem, tree, "the/actual", "KEKW");
+   path_tree_insert(&mem, tree, "me/am/sad", NULL);
 
    path_tree_print(tree);
 
@@ -1280,6 +1282,18 @@ int main/*_finds_nodes_by_path*/()
 
    printf("\n[STATUS] Trying to find [me]...\n");
    prints_out_find_status(tree, "me", "me", "hello!");
+
+   printf("\n[STATUS] Now finding and printing out a middle node [the/actual]...\n");
+   struct PathTree* found = path_tree_find_node_by_path(tree, "the/actual");
+   path_tree_print(found);
+
+   printf("\n[STATUS] Now finding and printing out an endpoint node [me/am/bad]...\n");
+   found = path_tree_find_node_by_path(tree, "me/am/bad");
+   path_tree_print(found);
+
+   printf("\n[STATUS] Now finding and printing out an empty endpoint node [me/am/sad]...\n");
+   found = path_tree_find_node_by_path(tree, "me/am/sad");
+   path_tree_print(found);
 
    printf("\n[STATUS] Trying to find [me/am/bad]...\n");
    prints_out_find_status(tree, "me/am/bad", "bad", "sry :(");

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -1239,7 +1239,7 @@ int main_checks_nonverbose_printing_of_empty_trees()
    return 0;
 }
 
-void prints_out_find_status(struct PathTree* tree, char* path)
+void prints_out_find_status(struct PathTree* tree, char* path, char* expected_name, char* expected_value)
 {
    assert(tree);
    assert(path);
@@ -1248,8 +1248,15 @@ void prints_out_find_status(struct PathTree* tree, char* path)
    if(!found)
       printf("[FIND STATE] Node not found!\n");
    else
+   {
+      assert(!strcmp(found->node_name, expected_name));
+      if(found->node_value)
+         assert(!strcmp(found->node_value, expected_value));
+      else
+         assert(found->node_value == expected_value && !found->node_value);
       printf("[FIND STATE] Found node:\n");
       printf("             %s: [%s]\n", found->node_name, found->node_value);
+   }
 }
 
 int main/*_finds_nodes_by_path*/()
@@ -1269,26 +1276,81 @@ int main/*_finds_nodes_by_path*/()
    path_tree_print(tree);
 
    printf("\n[STATUS] Trying to find [m]...\n");
-   prints_out_find_status(tree, "m");
+   prints_out_find_status(tree, "m", "m", "W");
 
    printf("\n[STATUS] Trying to find [me]...\n");
-   prints_out_find_status(tree, "me");
+   prints_out_find_status(tree, "me", "me", "hello!");
 
    printf("\n[STATUS] Trying to find [me/am/bad]...\n");
-   prints_out_find_status(tree, "me/am/bad");
+   prints_out_find_status(tree, "me/am/bad", "bad", "sry :(");
 
    printf("\n[STATUS] Trying to find [me/am]...\n");
-   prints_out_find_status(tree, "me/am");
+   prints_out_find_status(tree, "me/am", "am", NULL);
 
    printf("\n[STATUS] Trying to find [the/actual/gibberish/mwahaha/very/funny/yes]...\n");
-   prints_out_find_status(tree, "the/actual/gibberish/mwahaha/very/funny/yes");
+   prints_out_find_status(tree, "the/actual/gibberish/mwahaha/very/funny/yes", "yes", "I know Kappa");
+
+   printf("\n[STATUS] Trying to find [the/actual/gibberish/is/going/on/right/now]...\n");
+   prints_out_find_status(tree, "the/actual/gibberish/is/going/on/right/now", "now", "no clue ^_^");
 
    printf("\n[STATUS] Trying to find [the/actual/what/am/I/doing/right/now]...\n");
-   prints_out_find_status(tree, "the/actual/what/am/I/doing/right/now");
+   prints_out_find_status(tree, "the/actual/what/am/I/doing/right/now", "now", "*shrugs*");
 
    printf("\n[STATUS] App memory state: ");
    memory_usage_status(&mem);
    printf("\nmain_finds_nodes_by_path: OK\n");
+   free(mem.pointer);
+   return 0;
+}
+
+int main_tries_to_bork_find_node_by_path()
+{
+   printf("\nmain_tries_to_bork_find_node_by_path:\n");
+   Memory mem = memory_create(2 * KB);
+
+   printf("\n[STATUS] Creating a tree with 5 nodes...\n");
+   struct PathTree* tree = path_tree_create(&mem);
+   path_tree_insert(&mem, tree, "m", "W");
+   path_tree_insert(&mem, tree, "me", "hello!");
+   path_tree_insert(&mem, tree, "me/am/bad", "sry :(");
+   path_tree_insert(&mem, tree, "the/actual/what/am/I/doing/right/now", "*shrugs*");
+   path_tree_insert(&mem, tree, "the/actual/gibberish/is/going/on/right/now", "no clue ^_^");
+   path_tree_insert(&mem, tree, "the/actual/gibberish/mwahaha/very/funny/yes", "I know Kappa");
+
+   path_tree_print(tree);
+
+   printf("\n[STATUS] Trying to find \"\". Found node should be NULL...\n");
+   assert(!path_tree_find_node_by_path(tree, ""));
+
+   printf("\n[STATUS] Trying to find \"/incorrect/path\". Found node should be NULL...\n");
+   assert(!path_tree_find_node_by_path(tree, "/incorrect/path"));
+
+   printf("\n[STATUS] Trying to find \"incorrect/path/\". Found node should be NULL...\n");
+   assert(!path_tree_find_node_by_path(tree, "incorrect/path/"));
+
+   printf("\n[STATUS] Trying to find \"incorrect//path\". Found node should be NULL...\n");
+   assert(!path_tree_find_node_by_path(tree, "incorrect//path/"));
+
+   printf("\n[STATUS] Trying to find \"///truly///incorrect//path//\". Found node should be NULL...\n");
+   assert(!path_tree_find_node_by_path(tree, "incorrect//path/"));
+
+   printf("\n[STATUS] Trying to find a non-existing node [i/am/not/here]. Found node should be NULL...\n");
+   assert(!path_tree_find_node_by_path(tree, "i/am/not/here"));
+
+   printf("\n[STATUS] Trying to find an empty node in an empty tree... Found node should be NULL...\n");
+   struct PathTree* empty_tree = path_tree_create(&mem);
+   assert(!path_tree_find_node_by_path(empty_tree, ""));
+
+   printf("\n[STATUS] Trying to find [some/random/path] in an empty tree... Found node should be NULL...\n");
+   assert(!path_tree_find_node_by_path(empty_tree, "some/random/path"));
+
+   printf("\n[STATUS] Trying to find a short [a] node in a tree where it is the only node... Found node should be NULL...\n");
+   path_tree_insert(&mem, empty_tree, "a", "K");
+   prints_out_find_status(tree, "a", "a", "K");
+
+   printf("\n[STATUS] App memory state: ");
+   memory_usage_status(&mem);
+   printf("\nmain_tries_to_bork_find_node_by_path: OK\n");
    free(mem.pointer);
    return 0;
 }

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -1358,7 +1358,7 @@ int main_tries_to_bork_find_node_by_path()
    printf("\n[STATUS] Trying to find [some/random/path] in an empty tree... Found node should be NULL...\n");
    assert(!path_tree_find_node_by_path(empty_tree, "some/random/path"));
 
-   printf("\n[STATUS] Trying to find a short [a] node in a tree where it is the only node... Found node should be NULL...\n");
+   printf("\n[STATUS] Trying to find a short [a] node in a tree where it is the only node...\n");
    path_tree_insert(&mem, empty_tree, "a", "K");
    prints_out_find_status(tree, "a", "a", "K");
 
@@ -1369,7 +1369,7 @@ int main_tries_to_bork_find_node_by_path()
    return 0;
 }
 
-int main/*_finds_single_node_and_prints_it*/()
+int main_finds_single_node_and_prints_it()
 {
    printf("\nmain_finds_single_node_and_prints_it:\n");
    Memory mem = memory_create(2 * KB);

--- a/src/levi/test.c
+++ b/src/levi/test.c
@@ -1259,7 +1259,7 @@ void prints_out_find_status(struct PathTree* tree, char* path, char* expected_na
    }
 }
 
-int main/*_finds_nodes_by_path*/()
+int main_finds_nodes_by_path()
 {
    printf("\nmain_finds_nodes_by_path:\n");
    Memory mem = memory_create(2 * KB);
@@ -1365,6 +1365,61 @@ int main_tries_to_bork_find_node_by_path()
    printf("\n[STATUS] App memory state: ");
    memory_usage_status(&mem);
    printf("\nmain_tries_to_bork_find_node_by_path: OK\n");
+   free(mem.pointer);
+   return 0;
+}
+
+int main/*_finds_single_node_and_prints_it*/()
+{
+   printf("\nmain_finds_single_node_and_prints_it:\n");
+   Memory mem = memory_create(2 * KB);
+
+   printf("\n[STATUS] Creating a tree with 8 nodes...\n");
+   struct PathTree* tree = path_tree_create(&mem);
+   path_tree_insert(&mem, tree, "m", "W");
+   path_tree_insert(&mem, tree, "me", "hello!");
+   path_tree_insert(&mem, tree, "me/am/bad", "sry :(");
+   path_tree_insert(&mem, tree, "the/actual/what/am/I/doing/right/now", "*shrugs*");
+   path_tree_insert(&mem, tree, "the/actual/gibberish/is/going/on/right/now", "no clue ^_^");
+   path_tree_insert(&mem, tree, "the/actual/gibberish/mwahaha/very/funny/yes", "I know Kappa");
+   path_tree_insert(&mem, tree, "the/actual", "KEKW");
+   path_tree_insert(&mem, tree, "me/am/sad", NULL);
+
+   path_tree_print(tree);
+
+   printf("\n[STATUS] Trying to find [m]...\n");
+   path_tree_find_and_print_node(tree, "m");
+
+   printf("\n[STATUS] Trying to find [me]...\n");
+   path_tree_find_and_print_node(tree, "me");
+
+   printf("\n[STATUS] Now finding and printing out a middle node [the/actual]...\n");
+   path_tree_find_and_print_node(tree, "the/actual");
+
+   printf("\n[STATUS] Now finding and printing out an endpoint node [me/am/bad]...\n");
+   path_tree_find_and_print_node(tree, "me/am/bad");
+
+   printf("\n[STATUS] Now finding and printing out an empty endpoint node [me/am/sad]...\n");
+   path_tree_find_and_print_node(tree, "me/am/sad");
+
+   printf("\n[STATUS] Trying to find [me/am/bad]...\n");
+   path_tree_find_and_print_node(tree, "me/am/bad");
+
+   printf("\n[STATUS] Trying to find [me/am]...\n");
+   path_tree_find_and_print_node(tree, "me/am");
+
+   printf("\n[STATUS] Trying to find [the/actual/gibberish/mwahaha/very/funny/yes]...\n");
+   path_tree_find_and_print_node(tree, "the/actual/gibberish/mwahaha/very/funny/yes");
+
+   printf("\n[STATUS] Trying to find [the/actual/gibberish/is/going/on/right/now]...\n");
+   path_tree_find_and_print_node(tree, "the/actual/gibberish/is/going/on/right/now");
+
+   printf("\n[STATUS] Trying to find [the/actual/what/am/I/doing/right/now]...\n");
+   path_tree_find_and_print_node(tree, "the/actual/what/am/I/doing/right/now");
+
+   printf("\n[STATUS] App memory state: ");
+   memory_usage_status(&mem);
+   printf("\nmain_finds_single_node_and_prints_it: OK\n");
    free(mem.pointer);
    return 0;
 }

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -93,7 +93,7 @@ static struct PathTree* path_tree_find_starting_point_for_path_creation(
    assert(tree);
    assert(buffers->path);
 
-   if(util_string_is_null_or_empty(buffers->path))
+   if(util_string_is_null_or_empty(buffers->path) || !tree->children)
       return NULL;
 
    char* looking_for_this = util_chop_current_name_off_path_noalloc(&buffers->path);
@@ -323,7 +323,7 @@ struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char* path)
    assert(path);
    assert(tree);
 
-   if(path_tree_is_path_malformed(path) || !tree->children)
+   if(path_tree_is_path_malformed(path))
       return NULL;
 
    Memory throwaway_memory = memory_create(strlen(path) * 4 + 5);
@@ -343,27 +343,15 @@ struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char* path)
    return found;
 }
 
-void path_tree_find_and_print_node(struct PathTree* node, char* path)
+void path_tree_find_and_print_node(struct PathTree* tree, char* path)
 {
-   assert(node);
+   assert(tree);
    assert(path);
 
    if(path_tree_is_path_malformed(path))
       return;
 
-   Memory throwaway_memory = memory_create(strlen(path) * 4 + 5);
-   char* buf_path = memory_allocate(&throwaway_memory, strlen(path) + 1);
-   char* buf_scanned_path = memory_allocate(&throwaway_memory, strlen(path) + 1);
-   strcpy(buf_path, path);
-   strcpy(buf_scanned_path, "");
-   struct CreationPointInternal buffers = {
-      .throwaway_memory = &throwaway_memory,
-      .creation_point = NULL,
-      .path = buf_path,
-      .scanned_path = buf_scanned_path
-   };
-   struct PathTree* found = path_tree_find_starting_point_for_path_creation(&buffers, node);
-
+   struct PathTree* found = path_tree_find_node_by_path(tree, path);
    if(found)
    {
       if(found->node_value)
@@ -371,6 +359,4 @@ void path_tree_find_and_print_node(struct PathTree* node, char* path)
       else
          printf("%s: [EMPTY]\n", path);
    }
-
-   free(throwaway_memory.pointer);
 }

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -86,11 +86,9 @@ struct CreationPointInternal
 };
 
 static struct PathTree* path_tree_find_starting_point_for_path_creation(
-            Memory* application_memory,
             struct CreationPointInternal* buffers,
             struct PathTree* tree)
 {
-   assert(application_memory);
    assert(buffers);
    assert(tree);
    assert(buffers->path);
@@ -135,7 +133,7 @@ static struct PathTree* path_tree_find_starting_point_for_path_creation(
 
    return (node_on_correct_path) ? 
             path_tree_find_starting_point_for_path_creation(
-               application_memory, buffers, 
+               buffers, 
                (struct PathTree*)node_on_correct_path->value
             ) :
             NULL;
@@ -209,7 +207,7 @@ int path_tree_insert(Memory* memory, struct PathTree* tree, char* path, char* va
    strcpy(buffers.scanned_path, "");
    struct PathTree* creation_point = 
                         path_tree_find_starting_point_for_path_creation(
-                              memory, &buffers, tree
+                              &buffers, tree
                         );
    if(!creation_point)
    {
@@ -312,7 +310,6 @@ extern struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char*
    if(path_tree_is_path_malformed(path))
       return NULL;
 
-
    Memory throwaway_memory = memory_create(strlen(path) * 4 + 5);
    char* buf_path = memory_allocate(&throwaway_memory, strlen(path) + 1);
    char* buf_scanned_path = memory_allocate(&throwaway_memory, strlen(path) + 1);
@@ -324,8 +321,7 @@ extern struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char*
       .path = buf_path,
       .scanned_path = buf_scanned_path
    };
-   struct PathTree* found = path_tree_find_starting_point_for_path_creation(&throwaway_memory, &buffers, tree);
-   memory_usage_status(&throwaway_memory);
+   struct PathTree* found = path_tree_find_starting_point_for_path_creation(&buffers, tree);
    free(throwaway_memory.pointer);
 
    return found;

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -306,8 +306,9 @@ void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity)
 extern struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char* path)
 {
    assert(path);
+   assert(tree);
 
-   if(path_tree_is_path_malformed(path))
+   if(path_tree_is_path_malformed(path) || !tree->children)
       return NULL;
 
    Memory throwaway_memory = memory_create(strlen(path) * 4 + 5);

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -288,8 +288,23 @@ void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity)
    assert(tree);
 
    if(verbosity == PRINT_VERBOSE)
-      printf("%s: [EMPTY] [%p]\n", tree->node_name, tree);
-   if(path_tree_is_empty(tree))
+   {
+      printf("%s: ", tree->node_name);
+      if(!tree->node_value)
+         printf("[EMPTY] [%p]\n", tree);
+      else
+         printf("%s [%p]\n", tree->node_value, tree);
+   }
+   else if(verbosity == PRINT_NONVERBOSE &&
+           !path_tree_is_root_node(tree) && 
+           !tree->children)
+   {
+      if(tree->node_value)
+         printf("%s: %s\n", tree->node_name, tree->node_value);
+      else
+         printf("%s: [EMPTY]\n", tree->node_name);
+   }
+   if(!tree->children)
       return;
 
    Memory throwaway_memory = memory_create(THROWAWAY_MEMORY_SIZE_FOR_PRINT);

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -304,3 +304,29 @@ void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity)
 
    free(throwaway_memory.pointer);
 }
+
+extern struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char* path)
+{
+   assert(path);
+
+   if(path_tree_is_path_malformed(path))
+      return NULL;
+
+
+   Memory throwaway_memory = memory_create(strlen(path) * 4 + 5);
+   char* buf_path = memory_allocate(&throwaway_memory, strlen(path) + 1);
+   char* buf_scanned_path = memory_allocate(&throwaway_memory, strlen(path) + 1);
+   strcpy(buf_path, path);
+   strcpy(buf_scanned_path, "");
+   struct CreationPointInternal buffers = {
+      .throwaway_memory = &throwaway_memory,
+      .creation_point = NULL,
+      .path = buf_path,
+      .scanned_path = buf_scanned_path
+   };
+   struct PathTree* found = path_tree_find_starting_point_for_path_creation(&throwaway_memory, &buffers, tree);
+   memory_usage_status(&throwaway_memory);
+   free(throwaway_memory.pointer);
+
+   return found;
+}

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -318,7 +318,7 @@ void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity)
    free(throwaway_memory.pointer);
 }
 
-extern struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char* path)
+struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char* path)
 {
    assert(path);
    assert(tree);
@@ -341,4 +341,36 @@ extern struct PathTree* path_tree_find_node_by_path(struct PathTree* tree, char*
    free(throwaway_memory.pointer);
 
    return found;
+}
+
+void path_tree_find_and_print_node(struct PathTree* node, char* path)
+{
+   assert(node);
+   assert(path);
+
+   if(path_tree_is_path_malformed(path))
+      return;
+
+   Memory throwaway_memory = memory_create(strlen(path) * 4 + 5);
+   char* buf_path = memory_allocate(&throwaway_memory, strlen(path) + 1);
+   char* buf_scanned_path = memory_allocate(&throwaway_memory, strlen(path) + 1);
+   strcpy(buf_path, path);
+   strcpy(buf_scanned_path, "");
+   struct CreationPointInternal buffers = {
+      .throwaway_memory = &throwaway_memory,
+      .creation_point = NULL,
+      .path = buf_path,
+      .scanned_path = buf_scanned_path
+   };
+   struct PathTree* found = path_tree_find_starting_point_for_path_creation(&buffers, node);
+
+   if(found)
+   {
+      if(found->node_value)
+         printf("%s: %s\n", path, found->node_value);
+      else
+         printf("%s: [EMPTY]\n", path);
+   }
+
+   free(throwaway_memory.pointer);
 }


### PR DESCRIPTION
Functionality for finding nodes by path implemented:

- path_tree_find_node_by_path() finds nodes by their full path and returns a pointer to the found node or NULL;
- path_tree_find_and_print_node() finds the node and instead of returning it, prints it on the screen.