### PR TITLE
[0.6.0] pull request for issue #7: implemented set command in the shell

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -23,6 +23,7 @@ struct InitialCommandData
    struct Memory* application_memory;
    const char* original_getline;
    char* command_string;
+   struct PathTree* application_tree_root;
 };
 
 void* command_test_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data);

--- a/include/command.h
+++ b/include/command.h
@@ -33,4 +33,8 @@ void* command_exit_create_data_capsule(struct ShellCommand* command, struct Init
 void* command_exit_execute(void* data_capsule);
 void command_exit_process_result(void* data_capsule);
 
+void* command_set_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data);
+void* command_set_execute(void* data_capsule);
+void command_set_process_result(void* data_capsule);
+
 #endif

--- a/include/path_tree.h
+++ b/include/path_tree.h
@@ -18,7 +18,10 @@ struct PathTree
 };
 
 extern struct PathTree* path_tree_create(struct Memory* memory);
+
 extern int path_tree_is_empty(struct PathTree* tree);
+extern int path_tree_is_path_malformed(const char* path);
+
 extern int path_tree_insert(struct Memory* memory, struct PathTree* tree, char* path, char* value);
 
 extern void path_tree_print_choose_verbosity(struct PathTree* tree, int verbosity);

--- a/include/shell.h
+++ b/include/shell.h
@@ -9,6 +9,6 @@
 struct List* shell_create_command_list(struct Memory* memory);
 void shell_add_command(struct Memory* memory, struct List* command_list, char* command_name, ExecutorFunc executor, ExecutionResultProcessor result_processor, DataCapsuleCreator data_capsule_creator);
 void shell_process_command(struct List* command_list, struct InitialCommandData* command_data);
-struct InitialCommandData shell_pack_initial_data(struct Memory* application_memory, char* command_string);
+struct InitialCommandData shell_pack_initial_data(struct Memory* application_memory, char* command_string, struct PathTree* application_tree_root);
 
 #endif

--- a/src/levi/command.c
+++ b/src/levi/command.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 #include "command.h"
-#include "util.h"
+#include "liblevi.h"
 
 #define TEST_NO_ARGUMENT_RESPONSE "[TEST] No argument provided.\n"
 #define TEST_RESPONSE_WITH_ARGUMENT "[TEST] Argument provided: [%s]\n"
@@ -20,6 +20,16 @@ struct ExitDataCapsule
    const char* original_getline;
    struct Memory* application_memory;
    struct Memory* throwaway_memory;
+};
+
+struct SetDataCapsule
+{
+   struct Memory* application_memory;
+   struct Memory* throwaway_memory;
+   struct PathTree* application_tree_root;
+   char* new_node_path;
+   char* new_node_value;
+   int insert_exit_code;
 };
 
 void* command_test_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data)
@@ -104,17 +114,57 @@ void command_exit_process_result(void* data_capsule)
 
 void* command_set_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data)
 {
-   printf("[DEBUG] [command_set_create_data_capsule()]\n");
-   return NULL;
+   assert(command);
+   assert(initial_data);
+
+   struct Memory* throwaway_memory = memory_create_heap(1 * KB);
+   struct SetDataCapsule* data_capsule = memory_allocate(throwaway_memory, sizeof(struct SetDataCapsule));
+
+   data_capsule->application_memory = initial_data->application_memory;
+   data_capsule->application_tree_root = initial_data->application_tree_root;
+   data_capsule->throwaway_memory = throwaway_memory;
+   data_capsule->insert_exit_code = -2;
+
+   data_capsule->new_node_path = util_string_split_step(&initial_data->command_string, ' ', SPLIT_SKIP_EMPTY);
+   if(path_tree_is_path_malformed(data_capsule->new_node_path))
+      data_capsule->new_node_path = NULL;
+   data_capsule->new_node_value = util_string_split_step(&initial_data->command_string, ' ', SPLIT_SKIP_EMPTY);
+   if(util_string_is_null_or_empty(data_capsule->new_node_value))
+      data_capsule->new_node_value = NULL;
+
+   return data_capsule;
 }
 
 void* command_set_execute(void* data_capsule)
 {
-   printf("[DEBUG] [command_set_execute()]\n");
-   return NULL;
+   struct SetDataCapsule* set_data_capsule = data_capsule;
+   if(!set_data_capsule->new_node_path)
+      return set_data_capsule;
+
+   set_data_capsule->insert_exit_code = path_tree_insert(
+                                          set_data_capsule->application_memory,
+                                          set_data_capsule->application_tree_root,
+                                          set_data_capsule->new_node_path,
+                                          set_data_capsule->new_node_value
+                                        );
+
+   return set_data_capsule;
 }
 
 void command_set_process_result(void* data_capsule)
 {
-   printf("[DEBUG] [command_set_process_result()]\n");
+   struct SetDataCapsule* set_data_capsule = data_capsule;
+   if(!set_data_capsule->new_node_path || set_data_capsule->insert_exit_code == -1)
+   {
+      printf("[SET] The path to the node is malformed. Not setting anything.\n");
+      return;
+   }
+
+   printf("[SET] Node set successfully.\n");
+   printf("[SET] [DEBUG] Printing out the current tree:\n");
+   path_tree_print_verbose(set_data_capsule->application_tree_root);
+
+   struct Memory* throwaway_memory = set_data_capsule->throwaway_memory;
+   free(throwaway_memory->pointer);
+   free(throwaway_memory);
 }

--- a/src/levi/command.c
+++ b/src/levi/command.c
@@ -128,9 +128,11 @@ void* command_set_create_data_capsule(struct ShellCommand* command, struct Initi
    data_capsule->new_node_path = util_string_split_step(&initial_data->command_string, ' ', SPLIT_SKIP_EMPTY);
    if(path_tree_is_path_malformed(data_capsule->new_node_path))
       data_capsule->new_node_path = NULL;
-   data_capsule->new_node_value = util_string_split_step(&initial_data->command_string, ' ', SPLIT_SKIP_EMPTY);
-   if(util_string_is_null_or_empty(data_capsule->new_node_value))
+
+   if(util_string_is_null_or_empty(initial_data->command_string))
       data_capsule->new_node_value = NULL;
+   else
+      data_capsule->new_node_value = util_string_create(data_capsule->application_memory, initial_data->command_string, 0);
 
    return data_capsule;
 }

--- a/src/levi/command.c
+++ b/src/levi/command.c
@@ -157,14 +157,9 @@ void command_set_process_result(void* data_capsule)
 {
    struct SetDataCapsule* set_data_capsule = data_capsule;
    if(!set_data_capsule->new_node_path || set_data_capsule->insert_exit_code == -1)
-   {
       printf("[SET] The path to the node is malformed. Not setting anything.\n");
-      return;
-   }
-
-   printf("[SET] Node set successfully.\n");
-   printf("[SET] [DEBUG] Printing out the current tree:\n");
-   path_tree_print_verbose(set_data_capsule->application_tree_root);
+   else
+      printf("[SET] Node set successfully.\n");
 
    struct Memory* throwaway_memory = set_data_capsule->throwaway_memory;
    free(throwaway_memory->pointer);

--- a/src/levi/command.c
+++ b/src/levi/command.c
@@ -101,3 +101,20 @@ void command_exit_process_result(void* data_capsule)
    free(app_memory->pointer);
    exit(0);
 }
+
+void* command_set_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data)
+{
+   printf("[DEBUG] [command_set_create_data_capsule()]\n");
+   return NULL;
+}
+
+void* command_set_execute(void* data_capsule)
+{
+   printf("[DEBUG] [command_set_execute()]\n");
+   return NULL;
+}
+
+void command_set_process_result(void* data_capsule)
+{
+   printf("[DEBUG] [command_set_process_result()]\n");
+}

--- a/src/levi/main.c
+++ b/src/levi/main.c
@@ -38,7 +38,7 @@ void main_levi_shell_loop(struct List* command_list, struct Memory* application_
 int main()
 {
    printf("Welcome to leviathanK, a compact path tree explorer!\n");
-   printf("Current version is: [0.5.0]\n");
+   printf("Current version is: [0.6.0]\n");
 
    struct Memory application_memory = memory_create(1 * MB);
    struct List* command_list = shell_create_command_list(&application_memory);

--- a/src/levi/main.c
+++ b/src/levi/main.c
@@ -18,7 +18,7 @@ void print_available_commands(struct List* command_list)
    printf("]");
 }
 
-void main_levi_shell_loop(struct List* command_list, struct Memory* application_memory)
+void main_levi_shell_loop(struct List* command_list, struct Memory* application_memory, struct PathTree* application_tree_root)
 {
    while(TRUE)
    {
@@ -28,7 +28,7 @@ void main_levi_shell_loop(struct List* command_list, struct Memory* application_
       getline(&command_string, &zero, stdin);
       command_string[strlen(command_string) - 1] = '\0';
       
-      struct InitialCommandData data = shell_pack_initial_data(application_memory, command_string);
+      struct InitialCommandData data = shell_pack_initial_data(application_memory, command_string, application_tree_root);
       shell_process_command(command_list, &data);
 
       free(command_string);
@@ -42,11 +42,12 @@ int main()
 
    struct Memory application_memory = memory_create(1 * MB);
    struct List* command_list = shell_create_command_list(&application_memory);
+   struct PathTree* application_tree_root = path_tree_create(&application_memory);
 
    printf("Available commands: ");
    print_available_commands(command_list);
    printf("\n");
 
-   main_levi_shell_loop(command_list, &application_memory);
+   main_levi_shell_loop(command_list, &application_memory, application_tree_root);
 
 }

--- a/src/levi/shell.c
+++ b/src/levi/shell.c
@@ -6,6 +6,7 @@ struct List* shell_create_command_list(struct Memory* memory)
 {
    struct List* command_list = list_create_empty(memory);
 
+   shell_add_command(memory, command_list, "set", command_set_execute, command_set_process_result, command_set_create_data_capsule);
    shell_add_command(memory, command_list, "test", command_test_execute, command_test_process_result, command_test_create_data_capsule);
    shell_add_command(memory, command_list, "exit", command_exit_execute, command_exit_process_result, command_exit_create_data_capsule);
 

--- a/src/levi/shell.c
+++ b/src/levi/shell.c
@@ -77,7 +77,7 @@ void shell_process_command(struct List* command_list, struct InitialCommandData*
 }
 
 
-struct InitialCommandData shell_pack_initial_data(struct Memory* application_memory, char* command_string)
+struct InitialCommandData shell_pack_initial_data(struct Memory* application_memory, char* command_string, struct PathTree* application_tree_root)
 {
    assert(application_memory);
    assert(command_string);
@@ -85,6 +85,7 @@ struct InitialCommandData shell_pack_initial_data(struct Memory* application_mem
    return (struct InitialCommandData) {
       .application_memory = application_memory,
       .original_getline = (const char*) command_string,
-      .command_string = command_string
+      .command_string = command_string,
+      .application_tree_root = application_tree_root
    };
 }

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -106,7 +106,7 @@ static struct PathTree* path_tree_find_starting_point_for_path_creation(
 
    if(!buffers->creation_point)
    {
-      buffers->creation_point = util_string_create(buffers->throwaway_memory, "", 0.2 * buffers->throwaway_memory->capacity);
+      buffers->creation_point = util_string_create(buffers->throwaway_memory, "", 0.25 * buffers->throwaway_memory->capacity);
       strcpy(buffers->creation_point, "");
    }
 
@@ -194,7 +194,7 @@ int path_tree_insert(struct Memory* memory, struct PathTree* tree, char* path, c
       return 0;
    }
 
-   struct Memory throwaway_memory = memory_create(strlen(path) * 5);
+   struct Memory throwaway_memory = memory_create(strlen(path) * 5 + 5);
    struct CreationPointInternal buffers = {
       .throwaway_memory = &throwaway_memory,
       .creation_point = NULL,

--- a/src/lib/path_tree.c
+++ b/src/lib/path_tree.c
@@ -157,7 +157,7 @@ static void path_tree_create_new_branch_on_this_node(
    list_insert_tail(memory, tree_to_insert_into->children, new_node);
 }
 
-static int path_tree_is_path_malformed(const char* path)
+int path_tree_is_path_malformed(const char* path)
 {
    assert(path);
    size_t path_len = strlen(path);

--- a/src/lib/util.c
+++ b/src/lib/util.c
@@ -53,7 +53,7 @@ void util_build_path_prefix_noalloc(char** old_path_ptr, char* new_name)
       return;
    else if (util_string_is_null_or_empty(*old_path_ptr))
    {
-      strcat(*old_path_ptr, new_name);
+      strcpy(*old_path_ptr, new_name);
       return;
    }
    else if (util_string_is_null_or_empty(new_name))


### PR DESCRIPTION
Set command implemented in the LEVI shell.

- `set` - no arguments set is considered invalid because path to the new node cannot be an empty string.
- `set <path>` - either creates a new node at \<path\> and sets its value to NULL if the node does not exist yet, or empties the value at \<path\> if it had already existed before the command call.
- `set <path> <value>` sets node at \<path\> to the \<value\>.