### PR TITLE
[0.6.2] pull request for issue #6: partial implementation of the print command in the shell

### DIFF
--- a/include/command.h
+++ b/include/command.h
@@ -38,4 +38,8 @@ void* command_set_create_data_capsule(struct ShellCommand* command, struct Initi
 void* command_set_execute(void* data_capsule);
 void command_set_process_result(void* data_capsule);
 
+void* command_print_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data);
+void* command_print_execute(void* data_capsule);
+void command_print_process_result(void* data_capsule);
+
 #endif

--- a/include/path_tree.h
+++ b/include/path_tree.h
@@ -21,6 +21,7 @@ extern struct PathTree* path_tree_create(struct Memory* memory);
 
 extern int path_tree_is_empty(struct PathTree* tree);
 extern int path_tree_is_path_malformed(const char* path);
+extern int path_tree_is_root_node(struct PathTree* node);
 
 extern int path_tree_insert(struct Memory* memory, struct PathTree* tree, char* path, char* value);
 

--- a/src/levi/command.c
+++ b/src/levi/command.c
@@ -165,3 +165,18 @@ void command_set_process_result(void* data_capsule)
    free(throwaway_memory->pointer);
    free(throwaway_memory);
 }
+
+void* command_print_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data)
+{
+   printf("[DEBUG] [command_print_create_data_capsule()]\n");
+}
+
+void* command_print_execute(void* data_capsule)
+{
+   printf("[DEBUG] [command_print_execute()]\n");
+}
+
+void command_print_process_result(void* data_capsule)
+{
+   printf("[DEBUG] [command_print_process_result()]\n");
+}

--- a/src/levi/command.c
+++ b/src/levi/command.c
@@ -8,6 +8,8 @@
 #define TEST_NO_ARGUMENT_RESPONSE "[TEST] No argument provided.\n"
 #define TEST_RESPONSE_WITH_ARGUMENT "[TEST] Argument provided: [%s]\n"
 
+#define PRINT_NODE_NOT_FOUND -1
+
 struct TestDataCapsule
 {
    char* test_argument;
@@ -30,6 +32,15 @@ struct SetDataCapsule
    char* new_node_path;
    char* new_node_value;
    int insert_exit_code;
+};
+
+struct PrintDataCapsule
+{
+   struct Memory* throwaway_memory;
+   struct PathTree* application_tree_root;
+   char* requested_node_path;
+   int requested_verbosity_level;
+   struct PathTree* requested_node;
 };
 
 void* command_test_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data)
@@ -168,15 +179,80 @@ void command_set_process_result(void* data_capsule)
 
 void* command_print_create_data_capsule(struct ShellCommand* command, struct InitialCommandData* initial_data)
 {
-   printf("[DEBUG] [command_print_create_data_capsule()]\n");
+   assert(command);
+   assert(initial_data);
+
+   size_t alloc_size = sizeof(struct PrintDataCapsule) + 2 * (strlen(initial_data->command_string) + 1);
+   struct Memory* throwaway_memory = memory_create_heap(alloc_size);
+   struct PrintDataCapsule* data_capsule = memory_allocate(throwaway_memory, sizeof(struct PrintDataCapsule));
+
+   data_capsule->application_tree_root = initial_data->application_tree_root;
+   data_capsule->throwaway_memory = throwaway_memory;
+   data_capsule->requested_node = NULL;
+
+   char* first_argument = util_string_split_step(&initial_data->command_string, ' ', SPLIT_SKIP_EMPTY);
+   data_capsule->requested_verbosity_level = !strcmp(first_argument, "verbose") ? PRINT_VERBOSE : PRINT_NONVERBOSE;
+
+   if(data_capsule->requested_verbosity_level == PRINT_VERBOSE)
+      data_capsule->requested_node_path = util_string_split_step(&initial_data->command_string, ' ', SPLIT_SKIP_EMPTY);
+   else if(data_capsule->requested_verbosity_level == PRINT_NONVERBOSE)
+      data_capsule->requested_node_path = first_argument;
+   if(strcmp(data_capsule->requested_node_path, "") && path_tree_is_path_malformed(data_capsule->requested_node_path))
+      data_capsule->requested_node_path = NULL;
+
+   if(data_capsule->requested_node_path)
+      data_capsule->requested_node_path = util_string_create(throwaway_memory, data_capsule->requested_node_path, 0);
+
+   return data_capsule;
 }
 
 void* command_print_execute(void* data_capsule)
 {
-   printf("[DEBUG] [command_print_execute()]\n");
+   struct PrintDataCapsule* print_data_capsule = data_capsule;
+   if(!print_data_capsule->requested_node_path)
+   {
+      print_data_capsule->requested_node = NULL;
+      return print_data_capsule;
+   }
+   else if(!strcmp(print_data_capsule->requested_node_path, ""))
+   {
+      print_data_capsule->requested_node = print_data_capsule->application_tree_root;
+      return print_data_capsule;
+   }
+   
+   struct PathTree* found = path_tree_find_node_by_path(print_data_capsule->application_tree_root, print_data_capsule->requested_node_path);
+   print_data_capsule->requested_node = found ? found : (void*)PRINT_NODE_NOT_FOUND;
+
+   return print_data_capsule;
 }
 
 void command_print_process_result(void* data_capsule)
 {
-   printf("[DEBUG] [command_print_process_result()]\n");
+   struct PrintDataCapsule* print_data_capsule = data_capsule;
+
+   if(!print_data_capsule->requested_node)
+      printf("[PRINT] Path to the requested node is malformed. Not printing anything.\n");
+   else if(print_data_capsule->requested_node == (void*)PRINT_NODE_NOT_FOUND)
+      printf("[PRINT] Requested node not found.\n");
+   else
+   {
+      if(print_data_capsule->requested_verbosity_level == PRINT_NONVERBOSE)
+      {
+         if(!path_tree_is_root_node(print_data_capsule->requested_node))
+            printf("Requested node -> ");
+         path_tree_find_and_print_node(print_data_capsule->application_tree_root, print_data_capsule->requested_node_path);
+         if(print_data_capsule->requested_node->children)
+         {
+            if(!path_tree_is_root_node(print_data_capsule->requested_node))
+               printf("Node's children:\n");
+            path_tree_print(print_data_capsule->requested_node);
+         }
+      }
+      else if(print_data_capsule->requested_verbosity_level == PRINT_VERBOSE)
+         path_tree_print_verbose(print_data_capsule->requested_node);
+   }
+
+   struct Memory* throwaway_memory = print_data_capsule->throwaway_memory;
+   free(throwaway_memory->pointer);
+   free(throwaway_memory);
 }

--- a/src/levi/main.c
+++ b/src/levi/main.c
@@ -38,7 +38,7 @@ void main_levi_shell_loop(struct List* command_list, struct Memory* application_
 int main()
 {
    printf("Welcome to leviathanK, a compact path tree explorer!\n");
-   printf("Current version is: [0.7.0]\n");
+   printf("Current version is: [0.6.2]\n");
 
    struct Memory application_memory = memory_create(1 * MB);
    struct List* command_list = shell_create_command_list(&application_memory);

--- a/src/levi/main.c
+++ b/src/levi/main.c
@@ -38,7 +38,7 @@ void main_levi_shell_loop(struct List* command_list, struct Memory* application_
 int main()
 {
    printf("Welcome to leviathanK, a compact path tree explorer!\n");
-   printf("Current version is: [0.6.0]\n");
+   printf("Current version is: [0.7.0]\n");
 
    struct Memory application_memory = memory_create(1 * MB);
    struct List* command_list = shell_create_command_list(&application_memory);

--- a/src/levi/shell.c
+++ b/src/levi/shell.c
@@ -7,6 +7,7 @@ struct List* shell_create_command_list(struct Memory* memory)
    struct List* command_list = list_create_empty(memory);
 
    shell_add_command(memory, command_list, "set", command_set_execute, command_set_process_result, command_set_create_data_capsule);
+   shell_add_command(memory, command_list, "print", command_print_execute, command_print_process_result, command_print_create_data_capsule);
    shell_add_command(memory, command_list, "test", command_test_execute, command_test_process_result, command_test_create_data_capsule);
    shell_add_command(memory, command_list, "exit", command_exit_execute, command_exit_process_result, command_exit_create_data_capsule);
 


### PR DESCRIPTION
This pull request implements the print command including printing the tree or nodes verbosely and non-verbosely. 
**Usage:**
- `print` <- print the entire tree non-verbosely. WARNING: prints nothing if the tree is empty.
- `print verbose` <- print the entire tree verbosely, that is, including printing all the empty nodes and the pointers to all the nodes.
- `print [path_to_node]` <- prints node at [path_to_node] and its children if any non-verbosely, that is, only non-empty nodes, in the format of `[path] : [value]`.
- `print verbose [path_to_node]` <- prints node at [path_to_node] and all its children verbosely. That is, including all the empty nodes, in the format of `[path]: [value] [hex value of pointer_to_node]`. If the node is empty, prints `[path]: [EMPTY]`.

**NOTE:**
This implementation has a couple of bugs. Unfortunately, because of the fact that I'm in the process of a challenge (1 project a month), April 2020 is coming to an end and therefore my time for leviathanK Run One has run out. A bug GitHub issue (#27) has been created to address that, and when/if I return to leviathanK in the future, I'm hoping to address that.